### PR TITLE
Bugfix/issue 14

### DIFF
--- a/src/main/java/acc/hotsix/file_share/application/FileUpdateServiceImpl.java
+++ b/src/main/java/acc/hotsix/file_share/application/FileUpdateServiceImpl.java
@@ -7,6 +7,7 @@ import acc.hotsix.file_share.global.error.FileTypeMismatchException;
 import acc.hotsix.file_share.global.error.UploadFileException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;
@@ -27,7 +28,11 @@ public class FileUpdateServiceImpl implements FileUpdateService {
         File fileMetaData = fileService.getFileById(Long.parseLong(fileId));
 
         // 파일 타입 동일 여부 확인
-        if (!file.getContentType().equals(fileMetaData.getFileType())) {
+        String fileType = StringUtils.getFilenameExtension(file.getOriginalFilename());
+        if (fileType == null) {
+            fileType = file.getContentType();
+        }
+        if (!fileType.equals(fileMetaData.getFileType())) {
             throw new FileTypeMismatchException("File Type Mismatch");
         }
 

--- a/src/main/java/acc/hotsix/file_share/application/FileUploadServiceImpl.java
+++ b/src/main/java/acc/hotsix/file_share/application/FileUploadServiceImpl.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -72,10 +73,16 @@ public class FileUploadServiceImpl implements FileUploadService {
         double sizeInMegabytes = file.getSize() / (1024.0 * 1024.0);
         BigDecimal sizeRounded = new BigDecimal(sizeInMegabytes).setScale(2, RoundingMode.HALF_UP);
 
+        // 파일 메타 데이터 - 파일 타입
+        String fileType = StringUtils.getFilenameExtension(file.getOriginalFilename());
+        if (fileType == null) {
+            fileType = file.getContentType();
+        }
+
         // 파일 메타데이터 생성
         File fileMetaData = File.builder()
                 .name(file.getOriginalFilename())
-                .fileType(file.getContentType())
+                .fileType( fileType)
                 .lastModifiedAt(LocalDateTime.now())
                 .fileSize(sizeRounded.doubleValue())
                 .createdAt(LocalDateTime.now())


### PR DESCRIPTION
## 요약
현재 MultipartFile의 getContentType() 메소드 반환 값을 파일 타입으로 사용합니다 (MIME Type). 이를 파일의 확장자로 변경합니다. 
<br><br>
## 작업
- 파일 업로드 시 확장자를 저장하도록 수정
- 파일 수정 시 확장자를 비교하도록 수정
<br><br>
## 관련 이슈
- Close #14 